### PR TITLE
[MM-32709] Add a core-only flag to pass to the reconfigure command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,13 @@ $(tarname).tar.gz:
 download: check $(tarname).tar.gz
 
 
-clean: mmomni-clean
+deb-clean:
+	@rm -f *.deb
+
+
+clean: mmomni-clean omnitests-clean deb-clean
 	@echo "Cleaning generated files"
 	@rm -f *.tar.gz
-	@rm -f *.deb
 	@rm -rf build
 
 

--- a/mattermost-omnibus/DEBIAN/postinst
+++ b/mattermost-omnibus/DEBIAN/postinst
@@ -44,7 +44,7 @@ case "$1" in
             /opt/mattermost/mmomni/bin/mmomni init --fqdn "${mmDomain}" --email "${mmEmail}"
 
             # Reconfigure Omnibus
-            if /opt/mattermost/mmomni/bin/mmomni reconfigure; then
+            if /opt/mattermost/mmomni/bin/mmomni reconfigure --core-only ; then
                 # If everything went alright, print a success message
                 printSuccess
             else

--- a/mmomni/ansible/playbooks/reconfigure.yml
+++ b/mmomni/ansible/playbooks/reconfigure.yml
@@ -5,6 +5,9 @@
     - ansible_python_interpreter: /usr/bin/python3
     - logsettings_filelocation: /var/log/mattermost
     - nginx_template: mattermost.conf
+    # core_only is always received from reconfigure, but we set a
+    # default value in case the playbook is run independently
+    - core_only: True
   vars_files:
     - /etc/mattermost/mmomni.yml
 
@@ -123,5 +126,8 @@
             enabled: yes
             daemon_reload: yes
 
-    - include: jitsi/reconfigure.yml
-    - include: monitoring/reconfigure.yml
+    - name: "Components"
+      block:
+        - include: jitsi/reconfigure.yml
+        - include: monitoring/reconfigure.yml
+      when: not core_only|bool

--- a/omnitests/build.mk
+++ b/omnitests/build.mk
@@ -1,3 +1,7 @@
 omnitests/omnitests.test:
 	cd omnitests; \
 	./mage build
+
+omnitests-clean:
+	cd omnitests; \
+	rm -f omnitests.test


### PR DESCRIPTION
#### Summary
Adds a mechanism to run only the core parts of the playbook during the package lifecycle to avoid using `apt` inside an `apt` operation.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32709

