### PR TITLE
bump version

### DIFF
--- a/version.yml
+++ b/version.yml
@@ -1,6 +1,6 @@
 ---
 variables:
   MAJOR: 5
-  MINOR: 33
-  MINOR: 3
+  MINOR: 34
+  MINOR: 0
   REVISION: 0


### PR DESCRIPTION
#### Summary
Mattermost was jsut released https://github.com/mattermost/mattermost-server/releases/tag/v5.34.0
bumping the version on the main branch


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

