### PR TITLE
Removed a check that enforced email and FQDN to be set

### DIFF
--- a/mmomni/model/config.go
+++ b/mmomni/model/config.go
@@ -127,10 +127,6 @@ func (c *Config) IsValid() error {
 		return fmt.Errorf("database user cannot be empty")
 	}
 
-	if *c.FQDN != "" && *c.Email == "" {
-		return fmt.Errorf("email cannot be empty if fqdn is set")
-	}
-
 	if *c.HTTPS && (*c.FQDN == "" || *c.Email == "") {
 		return fmt.Errorf("fqdn and email must be set if https is enabled")
 	}


### PR DESCRIPTION
#### Summary
This PR removes a check that was enforcing `email` and `FQDN` to be set at the same time. This was only used for https, and there is another check that ensures that both properties are configured when `https` is set to true, so this restriction was unnecessary.