### PR TITLE
Ignore expired signatures for mirror

### DIFF
--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -22,8 +22,8 @@ case $opt in
         ;;
 esac
 
-aptly mirror create ${release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${release}
-aptly mirror update ${release}-mirror
+aptly mirror -ignore-signatures create ${release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${release} 
+aptly mirror -ignore-signatures update ${release}-mirror
 aptly repo create -distribution=${release} ${release}-repo
 aptly repo import ${release}-mirror ${release}-repo mattermost mattermost-omnibus
 if [[ "$nightly" == "true" ]]; then


### PR DESCRIPTION
Small change which will allow us to successfully mirror apt repository.

After first successful run, we need to revert those changes. 