### PR TITLE
Update repo-setup script to use curl binary full path

### DIFF
--- a/scripts/repo-setup.sh
+++ b/scripts/repo-setup.sh
@@ -59,6 +59,7 @@ validateAndAddMmKey() {
 ########################################################
 
 release=$(lsb_release -cs)
+curl_binary=$(which curl)
 
 if [[ "$release" != "bionic" && "$release" != "focal" ]]; then
     printf "ERROR: Unsupported ubuntu release: \"%s\"\n" "$release" >&2
@@ -85,14 +86,14 @@ esac
 
 # PostgreSQL
 pgKey=$(mktemp)
-curl https://www.postgresql.org/media/keys/ACCC4CF8.asc -o "$pgKey"
+"$curl_binary" https://www.postgresql.org/media/keys/ACCC4CF8.asc -o "$pgKey"
 pgFingerprint=$(getFingerprintFromFile "$pgKey")
 validateAndAddPgKey "$pgFingerprint" "$pgKey"
 add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt ${release}-pgdg main"
 
 # Mattermost Omnibus
 mmKey=$(mktemp)
-curl https://deb.packages.mattermost.com/pubkey.gpg -o "$mmKey"
+"$curl_binary" https://deb.packages.mattermost.com/pubkey.gpg -o "$mmKey"
 mmFingerprint=$(getFingerprintFromFile "$mmKey")
 validateAndAddMmKey "$mmFingerprint" "$mmKey"
 apt-add-repository -y "deb https://deb.packages.mattermost.com ${release} main"


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Substitute curl binary path, to bypass issues with curl binary not found under Ubuntu 20.04 due to sudo `secure_path` setting.


> **secure_path**

> _Path used for every command run from sudo. If you don't trust the people running sudo to have a sane PATH environment variable you may want to use this. Another use is if you want to have the “root path” be separate from the “user path”. Users in the group specified by the exempt_group option are not affected by secure_path. This option is not set by default._

Fixes: https://github.com/mattermost/mattermost-omnibus/issues/67

Ticket: https://mattermost.atlassian.net/browse/DOPS-929