### PR TITLE
Refactoring mattermost package, to suit for distribution 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,15 @@ mattermost_$(version)-$(revision).deb:
 	mkdir -p ${build_path}/${install_path}
 	tar xf ${tarname}.tar.gz --strip-components=1 -C ${build_path}/${install_path}
 
+	@echo "Renaming config file"
+	mv ${build_path}/opt/mattermost/config/config.json \
+	   ${build_path}/opt/mattermost/config/config.defaults.json
+
 	@echo "Creating binary links"
-	mkdir -p ${build_path}/usr/local/bin
-	ln -s ${install_path}/bin/mattermost ${build_path}/usr/local/bin/
-	ln -s ${install_path}/bin/platform ${build_path}/usr/local/bin/
-	ln -s ${install_path}/bin/mmctl ${build_path}/usr/local/bin/
+	mkdir -p ${build_path}/usr/bin
+	ln -s ${install_path}/bin/mattermost ${build_path}/usr/bin/
+	ln -s ${install_path}/bin/platform ${build_path}/usr/bin/
+	ln -s ${install_path}/bin/mmctl ${build_path}/usr/bin/
 
 	@echo "Copying systemd service"
 	mkdir -p ${build_path}/lib/systemd/system

--- a/mattermost/DEBIAN/postinst
+++ b/mattermost/DEBIAN/postinst
@@ -1,7 +1,36 @@
 #!/usr/bin/env bash
 
+set -e
+IS_UPGRADE=false
+
 case "$1" in
     configure)
+
+    MATTERMOST_USER=${MATTERMOST_USER:-mattermost}
+    MATTERMOST_GROUP=${MATTERMOST_GROUP:-mattermost}
+    if ! getent group "$MATTERMOST_GROUP" > /dev/null 2>&1 ; then
+       addgroup --system "$MATTERMOST_GROUP" --quiet > /dev/null 2>&1
+    fi
+    if ! id $MATTERMOST_USER > /dev/null 2>&1 ; then
+       adduser --system --home /opt/mattermost --no-create-home \
+       --ingroup "$MATTERMOST_GROUP" --disabled-password --shell /bin/false \
+       "$MATTERMOST_USER" > /dev/null 2>&1
+    fi
+
+    # Set user permisssions on /opt/mattermost
+    chown -R $MATTERMOST_USER:$MATTERMOST_GROUP /opt/mattermost
+
+    # If $1=configure and $2 is set, this is an upgrade
+    if [ "$2" != "" ]; then
+        IS_UPGRADE=true
+    fi
+
+    if [ "$IS_UPGRADE" != "true" ]; then
         systemctl daemon-reload
-        ;;
+        systemctl enable mattermost
+    else
+        systemctl daemon-reload
+        systemctl start mattermost > /dev/null 2>&1
+    fi
+    ;;
 esac

--- a/mattermost/DEBIAN/postinst
+++ b/mattermost/DEBIAN/postinst
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 
-set -e
+TRUE_REG='^([tT][rR][uU][eE]|[yY]|[yY][eE][sS]|1)$'
+FALSE_REG='^([fF][aA][lL][sS][eE]|[nN]|[nN][oO]|0)$'
 IS_UPGRADE=false
+
+IS_DEBUG=${IS_DEBUG:-false}
+if [[ $IS_DEBUG =~ $TRUE_REG ]]; then
+    set -o xtrace
+fi
+
+IS_STRICT=${IS_STRICT:-false}
+if [[ $IS_STRICT =~ $TRUE_REG ]]; then
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+fi
 
 case "$1" in
     configure)
@@ -25,7 +38,7 @@ case "$1" in
         IS_UPGRADE=true
     fi
 
-    if [ "$IS_UPGRADE" != "true" ]; then
+    if [[ ! "$IS_UPGRADE" =~ $TRUE_REG ]]; then
         systemctl daemon-reload
         systemctl enable mattermost
     else

--- a/mattermost/DEBIAN/postrm
+++ b/mattermost/DEBIAN/postrm
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 
-set -e
+TRUE_REG='^([tT][rR][uU][eE]|[yY]|[yY][eE][sS]|1)$'
+FALSE_REG='^([fF][aA][lL][sS][eE]|[nN]|[nN][oO]|0)$'
+
+IS_DEBUG=${IS_DEBUG:-false}
+if [[ $IS_DEBUG =~ $TRUE_REG ]]; then
+    set -o xtrace
+fi
+
+IS_STRICT=${IS_STRICT:-false}
+if [[ $IS_STRICT =~ $TRUE_REG ]]; then
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+fi
 
 case "$1" in
     remove)

--- a/mattermost/DEBIAN/postrm
+++ b/mattermost/DEBIAN/postrm
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 
+set -e
+
 case "$1" in
     remove)
-        systemctl daemon-reload
-        ;;
+
+    MATTERMOST_USER=${MATTERMOST_USER:-mattermost}
+    MATTERMOST_GROUP=${MATTERMOST_GROUP:-mattermost}
+    if id $MATTERMOST_USER > /dev/null 2>&1 ; then
+        deluser "$MATTERMOST_USER" > /dev/null 2>&1
+    fi
+    if getent group "$MATTERMOST_GROUP" > /dev/null 2>&1 ; then
+       delgroup "$MATTERMOST_GROUP" > /dev/null 2>&1
+    fi
+
+    systemctl daemon-reload
+    ;;
 esac

--- a/mattermost/DEBIAN/preinst
+++ b/mattermost/DEBIAN/preinst
@@ -1,7 +1,22 @@
 #!/usr/bin/env bash
 
-set -e
+TRUE_REG='^([tT][rR][uU][eE]|[yY]|[yY][eE][sS]|1)$'
+FALSE_REG='^([fF][aA][lL][sS][eE]|[nN]|[nN][oO]|0)$'
 IS_UPGRADE=false
+
+IS_DEBUG=${IS_DEBUG:-false}
+if [[ $IS_DEBUG =~ $TRUE_REG ]]; then
+    set -o xtrace
+fi
+
+IS_STRICT=${IS_STRICT:-false}
+if [[ $IS_STRICT =~ $TRUE_REG ]]; then
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+fi
+
+
 
 case "$1" in
     upgrade)
@@ -13,7 +28,7 @@ case "$1" in
         IS_UPGRADE=true
     fi
 
-    if [ "$IS_UPGRADE" == "true" ]; then
+    if [[ "$IS_UPGRADE" =~ $TRUE_REG ]]; then
         # Cleaning up old files
         find /opt/mattermost/ /opt/mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path /opt/mattermost/client -o -path /opt/mattermost/client/plugins -o -path /opt/mattermost/config -o -path /opt/mattermost/logs -o -path /opt/mattermost/plugins -o -path /opt/mattermost/data \) -prune \) -exec rm -r {} \;
     fi

--- a/mattermost/DEBIAN/preinst
+++ b/mattermost/DEBIAN/preinst
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 
+set -e
+IS_UPGRADE=false
+
 case "$1" in
     upgrade)
-        systemctl stop mattermost
-        ;;
+
+    systemctl stop mattermost
+
+    # If $1=configure and $2 is set, this is an upgrade
+    if [ "$2" != "" ]; then
+        IS_UPGRADE=true
+    fi
+
+    if [ "$IS_UPGRADE" == "true" ]; then
+        # Cleaning up old files
+        find /opt/mattermost/ /opt/mattermost/client/ -mindepth 1 -maxdepth 1 \! \( -type d \( -path /opt/mattermost/client -o -path /opt/mattermost/client/plugins -o -path /opt/mattermost/config -o -path /opt/mattermost/logs -o -path /opt/mattermost/plugins -o -path /opt/mattermost/data \) -prune \) -exec rm -r {} \;
+    fi
+    ;;
 esac

--- a/mattermost/DEBIAN/prerm
+++ b/mattermost/DEBIAN/prerm
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 
-set -e
+TRUE_REG='^([tT][rR][uU][eE]|[yY]|[yY][eE][sS]|1)$'
+FALSE_REG='^([fF][aA][lL][sS][eE]|[nN]|[nN][oO]|0)$'
+
+IS_DEBUG=${IS_DEBUG:-false}
+if [[ $IS_DEBUG =~ $TRUE_REG ]]; then
+    set -o xtrace
+fi
+
+IS_STRICT=${IS_STRICT:-false}
+if [[ $IS_STRICT =~ $TRUE_REG ]]; then
+    set -o errexit
+    set -o nounset
+    set -o pipefail
+fi
 
 case "$1" in
     remove)

--- a/mattermost/DEBIAN/prerm
+++ b/mattermost/DEBIAN/prerm
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 case "$1" in
     remove)
         systemctl stop mattermost

--- a/mattermost/files/mattermost.service
+++ b/mattermost/files/mattermost.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Mattermost
 After=network.target
-After=postgresql.service
-Requires=postgresql.service
 
 [Service]
 Type=notify
@@ -14,6 +12,7 @@ WorkingDirectory=/opt/mattermost
 User=mattermost
 Group=mattermost
 LimitNOFILE=49152
+Environment="MM_INSTALL_TYPE=ubuntu-testing"
 
 [Install]
-WantedBy=postgresql.service
+WantedBy=multi-user.target

--- a/mattermost/files/mattermost.service
+++ b/mattermost/files/mattermost.service
@@ -12,7 +12,7 @@ WorkingDirectory=/opt/mattermost
 User=mattermost
 Group=mattermost
 LimitNOFILE=49152
-Environment="MM_INSTALL_TYPE=ubuntu-testing"
+Environment="MM_INSTALL_TYPE=deb_package"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
We are introducing the following essential changes for `matermost` package, to better suit for distribution: 

- Change binary destination to `/usr/bin/` instead of `/usr/local/bin/` , to align with best practises. 
 `/usr/bin` is for distribution-managed normal user programs.
  `/usr/local/bin` is for normal user programs not managed by the distribution package manager, e.g. locally compiled packages. 
- Renaming config file from `config.json` to `config.defaults.json` to keep in case of upgrade/purge remove 
- Introduce logic, to define if this is a first time installation, or an upgrade 
- Create mattermost OS user/grp and define relevant permissions 
- Remove mattermost OS user/grp in case of removal
- Perform file cleanup(old mm version) in case of upgrade 
- Introduce env variable:`MM_INSTALL_TYPE` under runtime
- Remove postgresql dependency for `mattermost.service`


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
**Ticket:** https://mattermost.atlassian.net/browse/CLD-4311
