### PR TITLE
Ubuntu jammy 22.04 LTS support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ endif
 	@echo "Build for Mattermost Omnibus Nightly v${version}-${revision} ${release} succeeded"
 
 
-mattermost-omnibus: bin/mmomni mattermost-omnibus_$(version)-$(revision)_bionic.deb mattermost-omnibus_$(version)-$(revision)_focal.deb
+mattermost-omnibus: bin/mmomni mattermost-omnibus_$(version)-$(revision)_bionic.deb mattermost-omnibus_$(version)-$(revision)_focal.deb mattermost-omnibus_$(version)-$(revision)_jammy.deb
 
 
-mattermost-omnibus-nightly: bin/mmomni mattermost-omnibus-nightly_$(version)-$(revision)_bionic.deb mattermost-omnibus-nightly_$(version)-$(revision)_focal.deb
+mattermost-omnibus-nightly: bin/mmomni mattermost-omnibus-nightly_$(version)-$(revision)_bionic.deb mattermost-omnibus-nightly_$(version)-$(revision)_focal.deb mattermost-omnibus-nightly_$(version)-$(revision)_jammy.deb

--- a/mattermost-omnibus/files/jammy_dependencies
+++ b/mattermost-omnibus/files/jammy_dependencies
@@ -1,0 +1,2 @@
+python3, python3-psycopg2, ansible, postgresql-13 (>= 13.1-1.pgdg22.04+1), nginx (>= 1.18.0-1~focal), certbot (>= 0.40.0-1), python3-certbot-nginx (>= 0.40.0-0ubuntu0.1), debconf
+

--- a/scripts/repo-setup.sh
+++ b/scripts/repo-setup.sh
@@ -67,7 +67,7 @@ validateAndAddMmKey() {
 release=$(lsb_release -cs)
 curl_binary=$(which curl)
 
-if [[ "$release" != "bionic" && "$release" != "focal" ]]; then
+if [[ "$release" != "bionic" && "$release" != "focal" && "$release" != "jammy" ]]; then
     printf "ERROR: Unsupported ubuntu release: \"%s\"\n" "$release" >&2
     exit 1
 fi

--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -5,7 +5,7 @@ release=$1
 opt=${2:-false}
 nightly=false
 
-if [[ "${release}" != "bionic" && "${release}" != "focal" ]]; then
+if [[ "${release}" != "bionic" && "${release}" != "focal"  && "${release}" != "jammy" ]]; then
     printf "ERROR: unsupported release %q\n" "${release}" >&2
     exit 1
 fi


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adding support for Ubuntu Jammy 22.04LTS , for `mattermost-server` and `mattermost-omnibus` packages. 

- Refactor of `scripts/repo-setup.sh` & `scripts/sync-and-publish`
- Makefile Changes
- Introducing Jammy Dependencies for mattermost omnibus 


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/CLD-4483
