### PR TITLE
Fix apt-get update warnings by specifying the architecture for the repos

### DIFF
--- a/scripts/repo-setup.sh
+++ b/scripts/repo-setup.sh
@@ -88,6 +88,7 @@ validateAndAddMmKey() {
 ########################################################
 
 release=$(lsb_release -cs)
+architecture=$(dpkg-architecture -q DEB_HOST_ARCH)
 curl_binary=$(which curl)
 
 if [[ "$release" != "bionic" && "$release" != "focal" && "$release" != "jammy" ]]; then
@@ -111,13 +112,13 @@ if [[ $ARGUMENT_1 == "all" ]]; then
             apt-key adv --keyserver keyserver.ubuntu.com --recv-keys ABF5BD827BD9BF62
             nginxFingerprint=$(apt-key export ABF5BD827BD9BF62 2>/dev/null | getFingerprint)
             validateNginxKey "$nginxFingerprint"
-            add-apt-repository -y "deb https://nginx.org/packages/ubuntu/ ${release} nginx"
+            add-apt-repository -y "deb [arch=$architecture] https://nginx.org/packages/ubuntu/ ${release} nginx"
             # PostgreSQL
             pgKey=$(mktemp)
             "$curl_binary" -s https://www.postgresql.org/media/keys/ACCC4CF8.asc -o "$pgKey"
             pgFingerprint=$(getFingerprintFromFile "$pgKey")
             validateAndAddPgKey "$pgFingerprint" "$pgKey"
-            add-apt-repository -y "deb http://apt.postgresql.org/pub/repos/apt ${release}-pgdg main"
+            add-apt-repository -y "deb [arch=$architecture] http://apt.postgresql.org/pub/repos/apt ${release}-pgdg main"
             ;;
         jammy)
             # Nginx
@@ -155,7 +156,7 @@ if [[ $ARGUMENT_1 == "all" || $ARGUMENT_1 == "mattermost" ]] ; then
             "$curl_binary" -s https://deb.packages.mattermost.com/pubkey.gpg -o "$mmKey"
             mmFingerprint=$(getFingerprintFromFile "$mmKey")
             validateAndAddMmKey "$mmFingerprint" "$mmKey"
-            apt-add-repository -y "deb https://deb.packages.mattermost.com ${release} main"
+            apt-add-repository -y "deb [arch=$architecture] https://deb.packages.mattermost.com ${release} main"
             ;;
         jammy)
             # Mattermost Omnibus


### PR DESCRIPTION
Getting rid of these messages during `apt-get update`:

\# apt-get update
N: Skipping acquire of configured file 'nginx/binary-i386/Packages' as repository 'https://nginx.org/packages/ubuntu focal InRelease' doesn't support architecture 'i386'
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://deb.packages.mattermost.com focal InRelease' doesn't support architecture 'i386'
N: Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'http://apt.postgresql.org/pub/repos/apt focal-pgdg InRelease' doesn't support architecture 'i386'

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

