### PR TITLE
Add exit flag to postinst

### DIFF
--- a/mattermost/DEBIAN/postinst
+++ b/mattermost/DEBIAN/postinst
@@ -47,3 +47,5 @@ case "$1" in
     fi
     ;;
 esac
+
+exit 0


### PR DESCRIPTION
On my linux server (Ubuntu 22.04.2 LTS) with Mattermost Omnibus installed, I had the issue of being unable to upgrade or downgrade Mattermost. I kept getting errors like this:

```
Setting up mattermost (7.10.0-0) ...
dpkg: error processing package mattermost (--configure):
 installed mattermost package post-installation script subprocess returned error exit status 1
Errors were encountered while processing:
 mattermost
```

I also tried a complete uninstall and reinstall. Debug mode gave me a clue to an issue with the installation script:

`sudo dpkg --configure --debug=77777 mattermost`

After adding an `exit 0` to the end of the install script, I could finally finish the package configuration.
