### PR TITLE
Add Ubuntu Noble support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ endif
 	@echo "Build for Mattermost Omnibus Nightly v${version}-${revision} ${release} succeeded"
 
 
-mattermost-omnibus: bin/mmomni mattermost-omnibus_$(version)-$(revision)_focal.deb mattermost-omnibus_$(version)-$(revision)_jammy.deb
+mattermost-omnibus: bin/mmomni mattermost-omnibus_$(version)-$(revision)_focal.deb mattermost-omnibus_$(version)-$(revision)_jammy.deb mattermost-omnibus_$(version)-$(revision)_noble.deb
 
 
-mattermost-omnibus-nightly: bin/mmomni mattermost-omnibus-nightly_$(version)-$(revision)_focal.deb mattermost-omnibus-nightly_$(version)-$(revision)_jammy.deb
+mattermost-omnibus-nightly: bin/mmomni mattermost-omnibus-nightly_$(version)-$(revision)_focal.deb mattermost-omnibus-nightly_$(version)-$(revision)_jammy.deb mattermost-omnibus-nightly_$(version)-$(revision)_noble.deb

--- a/mattermost-omnibus/files/noble_dependencies
+++ b/mattermost-omnibus/files/noble_dependencies
@@ -1,0 +1,2 @@
+python3, python3-psycopg2, ansible, postgresql-13 (>= 13.15-1.pgdg24.04+1), nginx (>= 1.26.0-1~noble), certbot (>= 2.9.0-1), python3-certbot-nginx (>= 2.9.0-1), debconf
+

--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -5,7 +5,7 @@ release=$1
 opt=${2:-false}
 nightly=false
 
-if [[ "${release}" != "focal"  && "${release}" != "jammy" ]]; then
+if [[ "${release}" != "focal"  && "${release}" != "jammy" && "${release}" != "noble" ]]; then
     printf "ERROR: unsupported release %q\n" "${release}" >&2
     exit 1
 fi


### PR DESCRIPTION
#### Summary

Add Ubuntu Noble support for mattermost-omnibus.

The repository side of the Ubuntu Noble support is taken care of in a separate PR.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7799