### PR TITLE
Manual cherrypick 108

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ endif
 	@echo "Build for Mattermost Omnibus Nightly v${version}-${revision} ${release} succeeded"
 
 
-mattermost-omnibus: bin/mmomni mattermost-omnibus_$(version)-$(revision)_focal.deb mattermost-omnibus_$(version)-$(revision)_jammy.deb
+mattermost-omnibus: bin/mmomni mattermost-omnibus_$(version)-$(revision)_focal.deb mattermost-omnibus_$(version)-$(revision)_jammy.deb mattermost-omnibus_$(version)-$(revision)_noble.deb
 
 
-mattermost-omnibus-nightly: bin/mmomni mattermost-omnibus-nightly_$(version)-$(revision)_focal.deb mattermost-omnibus-nightly_$(version)-$(revision)_jammy.deb
+mattermost-omnibus-nightly: bin/mmomni mattermost-omnibus-nightly_$(version)-$(revision)_focal.deb mattermost-omnibus-nightly_$(version)-$(revision)_jammy.deb mattermost-omnibus-nightly_$(version)-$(revision)_noble.deb

--- a/mattermost-omnibus/files/noble_dependencies
+++ b/mattermost-omnibus/files/noble_dependencies
@@ -1,0 +1,2 @@
+python3, python3-psycopg2, ansible, postgresql-13 (>= 13.15-1.pgdg24.04+1), nginx (>= 1.26.0-1~noble), certbot (>= 2.9.0-1), python3-certbot-nginx (>= 2.9.0-1), debconf
+

--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -5,7 +5,7 @@ release=$1
 opt=${2:-false}
 nightly=false
 
-if [[ "${release}" != "focal"  && "${release}" != "jammy" ]]; then
+if [[ "${release}" != "focal"  && "${release}" != "jammy" && "${release}" != "noble" ]]; then
     printf "ERROR: unsupported release %q\n" "${release}" >&2
     exit 1
 fi

--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -4,6 +4,7 @@ set -xeuo pipefail
 release=$1
 opt=${2:-false}
 nightly=false
+mirror_release="$release"
 
 if [[ "${release}" != "focal"  && "${release}" != "jammy" && "${release}" != "noble" ]]; then
     printf "ERROR: unsupported release %q\n" "${release}" >&2
@@ -16,16 +17,19 @@ case $opt in
     --nightly)
         nightly=true
         ;;
+    --mirror-release=*)
+        mirror_release="${opt##--mirror-release=}"
+        ;;
     *)
         printf "ERROR: invalid option %q\n" "${opt}" >&2
         exit 1
         ;;
 esac
 
-aptly mirror create ${release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${release}
-aptly mirror update ${release}-mirror
+aptly mirror create ${mirror_release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${mirror_release}
+aptly mirror update ${mirror_release}-mirror
 aptly repo create -distribution=${release} ${release}-repo
-aptly repo import ${release}-mirror ${release}-repo mattermost mattermost-omnibus
+aptly repo import ${mirror_release}-mirror ${release}-repo mattermost mattermost-omnibus
 if [[ "$nightly" == "true" ]]; then
     aptly repo remove ${release}-repo mattermost-omnibus-nightly
     aptly repo add ${release}-repo mattermost-omnibus-nightly_*_${release}.deb

--- a/version.yml
+++ b/version.yml
@@ -1,6 +1,6 @@
 ---
 variables:
   MAJOR: 9
-  MINOR: 8
-  PATCH: 1
+  MINOR: 10
+  PATCH: 0
   REVISION: 0


### PR DESCRIPTION
#### Summary

Manual cherrypick of https://github.com/mattermost/mattermost-omnibus/pull/108

After this is merged, i'll move tag `v9.10.0-0` to the new `release-9.10` branch head, and trigger the ubuntu noble repo initialization.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7799
