### PR TITLE
Do not use another release when initializing a new release

### DIFF
--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -26,8 +26,10 @@ case $opt in
         ;;
 esac
 
-aptly mirror create ${mirror_release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${mirror_release}
-aptly mirror update ${mirror_release}-mirror
+if ! (aptly mirror list -raw | grep -E "^${mirror_release}-mirror$"); then
+  aptly mirror create ${mirror_release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${mirror_release}
+  aptly mirror update ${mirror_release}-mirror
+fi
 aptly repo create -distribution=${release} ${release}-repo
 aptly repo import ${mirror_release}-mirror ${release}-repo mattermost mattermost-omnibus
 if [[ "$nightly" == "true" ]]; then

--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -4,7 +4,7 @@ set -xeuo pipefail
 release=$1
 opt=${2:-false}
 nightly=false
-mirror_release="$release"
+init_release=false
 
 if [[ "${release}" != "focal"  && "${release}" != "jammy" && "${release}" != "noble" ]]; then
     printf "ERROR: unsupported release %q\n" "${release}" >&2
@@ -17,8 +17,8 @@ case $opt in
     --nightly)
         nightly=true
         ;;
-    --mirror-release=*)
-        mirror_release="${opt##--mirror-release=}"
+    --init-release)
+        init_release=true
         ;;
     *)
         printf "ERROR: invalid option %q\n" "${opt}" >&2
@@ -26,12 +26,14 @@ case $opt in
         ;;
 esac
 
-if ! (aptly mirror list -raw | grep -E "^${mirror_release}-mirror$"); then
-  aptly mirror create ${mirror_release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${mirror_release}
-  aptly mirror update ${mirror_release}-mirror
+if [[ "$init_release" == "false" ]]; then
+  aptly mirror create ${release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${release}
+  aptly mirror update ${release}-mirror
 fi
 aptly repo create -distribution=${release} ${release}-repo
-aptly repo import ${mirror_release}-mirror ${release}-repo mattermost mattermost-omnibus
+if [[ "$init_release" == "false" ]]; then
+  aptly repo import ${release}-mirror ${release}-repo mattermost mattermost-omnibus
+fi
 if [[ "$nightly" == "true" ]]; then
     aptly repo remove ${release}-repo mattermost-omnibus-nightly
     aptly repo add ${release}-repo mattermost-omnibus-nightly_*_${release}.deb

--- a/scripts/sync-and-publish
+++ b/scripts/sync-and-publish
@@ -4,7 +4,7 @@ set -xeuo pipefail
 release=$1
 opt=${2:-false}
 nightly=false
-init_release=false
+bootstrap_release=false
 
 if [[ "${release}" != "focal"  && "${release}" != "jammy" && "${release}" != "noble" ]]; then
     printf "ERROR: unsupported release %q\n" "${release}" >&2
@@ -17,8 +17,8 @@ case $opt in
     --nightly)
         nightly=true
         ;;
-    --init-release)
-        init_release=true
+    --bootstrap-release)
+        bootstrap_release=true
         ;;
     *)
         printf "ERROR: invalid option %q\n" "${opt}" >&2
@@ -26,12 +26,12 @@ case $opt in
         ;;
 esac
 
-if [[ "$init_release" == "false" ]]; then
+if [[ "$bootstrap_release" == "false" ]]; then
   aptly mirror create ${release}-mirror https://mattermost-repository-deb.s3.us-east-1.amazonaws.com ${release}
   aptly mirror update ${release}-mirror
 fi
 aptly repo create -distribution=${release} ${release}-repo
-if [[ "$init_release" == "false" ]]; then
+if [[ "$bootstrap_release" == "false" ]]; then
   aptly repo import ${release}-mirror ${release}-repo mattermost mattermost-omnibus
 fi
 if [[ "$nightly" == "true" ]]; then


### PR DESCRIPTION
#### Summary

The changes introduced in https://github.com/mattermost/mattermost-omnibus/pull/108 did not account for the fact that we cannot utilize another distribution's packages to initialize a repo: each Deb package is built with a distribution in mind, and comes [with its own set of dependencies](https://github.com/mattermost/mattermost-omnibus/tree/main/mattermost-omnibus/files) accordingly.

So for Ubuntu Noble, we need to start with an empty repository. Please let me know if you have differing thoughts on this.

#### Ticket Link

https://mattermost.atlassian.net/browse/CLD-7799

