### PR TITLE
Update mattermost.service for MM-59384.

### DIFF
--- a/mattermost/files/mattermost.service
+++ b/mattermost/files/mattermost.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Mattermost
-After=network.target
+After=network-online.target
 
 [Service]
 Type=notify

--- a/mmomni/ansible/playbooks/mattermost.service
+++ b/mmomni/ansible/playbooks/mattermost.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Mattermost
-After=network.target
+After=network-online.target
 After=postgresql.service
 Requires=postgresql.service
 


### PR DESCRIPTION


#### Summary
Makes the systemd mattermost.service depend on network-online.target rather than network.target.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost-omnibus/issues/113
also on JIRA as MM-59384.
