### PR TITLE
feat: Add support for configurable database host and SSL settings (#117)

### DIFF
--- a/mmomni/ansible/playbooks/mattermost.env
+++ b/mmomni/ansible/playbooks/mattermost.env
@@ -2,8 +2,8 @@
 # Omnibus generated configuration #
 ###################################
 MM_INSTALL_TYPE=omnibus
-MM_CONFIG=postgres://{{ db_user }}:{{ db_password }}@localhost:5432/mattermost?sslmode=disable&connect_timeout=10
-MM_SQLSETTINGS_DATASOURCE=postgres://{{ db_user }}:{{ db_password }}@localhost:5432/mattermost?sslmode=disable&connect_timeout=10
+MM_CONFIG=postgres://{{ db_user }}:{{ db_password }}@{{ db_host | default('localhost') }}:5432/mattermost?sslmode={{ db_use_ssl | default('disable') }}&connect_timeout=10
+MM_SQLSETTINGS_DATASOURCE=postgres://{{ db_user }}:{{ db_password }}@{{ db_host | default('localhost') }}:5432/mattermost?sslmode={{ db_use_ssl | default('disable') }}&connect_timeout=10
 {% if https %}
 MM_SERVICESETTINGS_SITEURL=https://{{ fqdn }}
 {% elif fqdn %}

--- a/mmomni/ansible/playbooks/reconfigure.yml
+++ b/mmomni/ansible/playbooks/reconfigure.yml
@@ -71,14 +71,17 @@
             name: "{{ db_user }}"
             password: "{{ db_password }}"
             encrypted: yes
+            login_host: "{{ db_host | default('localhost') }}"
 
         - name: "Create database for Mattermost"
           postgresql_db:
             name: mattermost
             owner: "{{ db_user }}"
+            login_host: "{{ db_host | default('localhost') }}"
 
       become: yes
       become_user: postgres
+      when: db_host is not defined or db_host == 'localhost'
 
     - name: "Mattermost"
       block:

--- a/mmomni/model/config.go
+++ b/mmomni/model/config.go
@@ -21,6 +21,8 @@ type Config struct {
 
 	DBUser              *string `yaml:"db_user"`
 	DBPassword          *string `yaml:"db_password"`
+	DBHost              *string `yaml:"db_host"`
+	DBUseSSL            *string `yaml:"db_use_ssl"`
 	FQDN                *string `yaml:"fqdn"`
 	Email               *string `yaml:"email"`
 	HTTPS               *bool   `yaml:"https"`
@@ -62,6 +64,14 @@ func (c *Config) SetDefaults() {
 
 	if c.DBPassword == nil {
 		c.DBPassword = NewString("")
+	}
+
+	if c.DBHost == nil {
+		c.DBHost = NewString("localhost")
+	}
+
+	if c.DBUseSSL == nil {
+		c.DBUseSSL = NewString("disable")
 	}
 
 	if c.FQDN == nil {
@@ -130,6 +140,10 @@ func (c *Config) PreSave() (*Config, error) {
 func (c *Config) IsValid() error {
 	if *c.DBUser == "" {
 		return fmt.Errorf("database user cannot be empty")
+	}
+
+	if *c.DBUseSSL != "disable" && *c.DBUseSSL != "require" {
+		return fmt.Errorf("db_use_ssl must be either 'disable' or 'require'")
 	}
 
 	if *c.HTTPS && (*c.FQDN == "" || *c.Email == "") {


### PR DESCRIPTION
#### Summary
This pull request adds an option to configure Mattermost Omnibus to use an external PostgreSQL database instead of the bundled one. When database connection details are provided in mmomni.yml or environment variables, it's used in the Mattermost environment configuration. If no external DB settings are given, the default bundled PostgreSQL setup is used.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-omnibus/issues/117


